### PR TITLE
ci(release): auto-bump Homebrew formula on non-prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -45,6 +46,7 @@ jobs:
         run: swift build -c release --product adevcontainer
 
       - name: Package binary and checksum
+        id: package
         shell: bash
         run: |
           set -euo pipefail
@@ -63,7 +65,14 @@ jobs:
           export COPYFILE_DISABLE=1
           tar -C dist -czf adevcontainer-macos-arm64.tar.gz adevcontainer
           shasum -a 256 adevcontainer-macos-arm64.tar.gz > adevcontainer-macos-arm64.tar.gz.sha256
+          SHA256="$(awk '{print $1}' adevcontainer-macos-arm64.tar.gz.sha256)"
+          if [[ ! "$SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "error: failed to parse sha256 from checksum file: ${SHA256}" >&2
+            exit 1
+          fi
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
           ls -la adevcontainer-macos-arm64.tar.gz adevcontainer-macos-arm64.tar.gz.sha256
+          echo "SHA256=${SHA256}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -76,3 +85,79 @@ jobs:
             adevcontainer-macos-arm64.tar.gz.sha256
           generate_release_notes: true
           fail_on_unmatched_files: true
+
+      - name: Bump Homebrew tap formula
+        if: ${{ !contains(steps.version.outputs.version, '-') }}
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA256: ${{ steps.package.outputs.sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
+            echo "error: HOMEBREW_TAP_TOKEN secret is not set." >&2
+            echo "Add a fine-grained PAT with Contents read/write on wcgomes/homebrew-tap" >&2
+            echo "(or a classic PAT with repo scope) as repo secret HOMEBREW_TAP_TOKEN." >&2
+            exit 1
+          fi
+          TAP_DIR="${RUNNER_TEMP}/homebrew-tap"
+          git clone --depth 1 \
+            "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/wcgomes/homebrew-tap.git" \
+            "${TAP_DIR}"
+          bash scripts/render-homebrew-formula.sh \
+            "${VERSION}" "${SHA256}" "${TAP_DIR}/Formula/adevcontainer.rb"
+          git -C "${TAP_DIR}" config user.name "github-actions[bot]"
+          git -C "${TAP_DIR}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "${TAP_DIR}" add Formula/adevcontainer.rb
+          if git -C "${TAP_DIR}" diff --cached --quiet; then
+            echo "Tap formula already at adevcontainer ${VERSION}; nothing to commit."
+          else
+            git -C "${TAP_DIR}" commit -m "adevcontainer ${VERSION}"
+            git -C "${TAP_DIR}" push origin HEAD:main
+            echo "Pushed Formula/adevcontainer.rb ${VERSION} to wcgomes/homebrew-tap"
+          fi
+
+      - name: Sync packaging formula via PR
+        if: ${{ !contains(steps.version.outputs.version, '-') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA256: ${{ steps.package.outputs.sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH="brew-bump-v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Drop inject-version / build dirt; branch from main (protected — PR only)
+          git fetch origin main
+          git checkout -f -B "${BRANCH}" origin/main
+          bash scripts/render-homebrew-formula.sh \
+            "${VERSION}" "${SHA256}" packaging/homebrew/adevcontainer.rb
+          git add packaging/homebrew/adevcontainer.rb
+          if git diff --cached --quiet; then
+            echo "packaging/homebrew/adevcontainer.rb already at ${VERSION}; skipping PR."
+            exit 0
+          fi
+          git commit -m "chore(homebrew): bump packaging formula to ${VERSION}"
+          git push -u origin "${BRANCH}" --force
+          BODY="## Summary
+          Mirror bump of \`packaging/homebrew/adevcontainer.rb\` to **${VERSION}** after the GitHub Release.
+
+          - version: \`${VERSION}\`
+          - sha256: \`${SHA256}\`
+          - tap \`wcgomes/homebrew-tap\` was updated in the same release job
+
+          Auto-opened by the Release workflow."
+          # Collapse accidental leading indent from YAML block
+          BODY="$(printf '%s\n' "${BODY}" | sed 's/^[[:space:]]*//')"
+          if [[ "$(gh pr list --head "${BRANCH}" --base main --json number --jq 'length')" == "0" ]]; then
+            gh pr create \
+              --base main \
+              --head "${BRANCH}" \
+              --title "chore(homebrew): bump packaging formula to ${VERSION}" \
+              --body "${BODY}"
+          else
+            echo "PR for ${BRANCH} already exists; branch updated."
+          fi

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,9 +1,6 @@
 # Homebrew formula (personal tap)
 
-1. Create or open `github.com/wcgomes/homebrew-tap`.
-2. Copy `adevcontainer.rb` to `Formula/adevcontainer.rb` in that repo.
-3. Per release: set `version`, confirm `url`, and replace `sha256` with the arm64 tarball digest (`shasum -a 256 adevcontainer-macos-arm64.tar.gz`).
-4. Users install with:
+Users install with:
 
 ```bash
 brew tap wcgomes/tap
@@ -11,3 +8,27 @@ brew install adevcontainer
 ```
 
 `brew tap wcgomes/tap` resolves to `homebrew-tap` on GitHub. Apple `container` stays a separate host dependency (see formula caveats).
+
+## Automatic updates on release
+
+On each **non-prerelease** GitHub Release (`vX.Y.Z`, no `-` in the version):
+
+1. **Tap (required for `brew upgrade`)** — the Release workflow renders `Formula/adevcontainer.rb` and pushes directly to `wcgomes/homebrew-tap` `main`.
+2. **Packaging mirror** — the same job opens a PR to this repo updating `packaging/homebrew/adevcontainer.rb` (branch protection blocks direct push to `main`).
+
+Prerelease tags (`vX.Y.Z-rc.1`, etc.) skip both Homebrew steps.
+
+### Required secret
+
+Configure repo secret **`HOMEBREW_TAP_TOKEN`**:
+
+- **Fine-grained PAT**: Contents read/write on `wcgomes/homebrew-tap` only, or
+- **Classic PAT**: `repo` scope
+
+Without this secret, non-prerelease releases fail at the tap-bump step so missing brew updates are visible.
+
+### Manual render (local)
+
+```bash
+scripts/render-homebrew-formula.sh 0.2.0 <sha256> packaging/homebrew/adevcontainer.rb
+```

--- a/scripts/render-homebrew-formula.sh
+++ b/scripts/render-homebrew-formula.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Render the adevcontainer Homebrew formula with version + sha256.
+# Usage: render-homebrew-formula.sh <VERSION> <SHA256> [output path]
+#   output path omitted or "-" → stdout
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <VERSION> <SHA256> [output path]" >&2
+  echo "  VERSION  semver X.Y.Z or X.Y.Z-prerelease (optional leading v stripped)" >&2
+  echo "  SHA256   64-char lowercase hex digest of adevcontainer-macos-arm64.tar.gz" >&2
+  echo "  output   file path, or omit/- for stdout" >&2
+  exit 1
+}
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  usage
+fi
+
+version="${1#v}"
+sha256="$2"
+out="${3:-}"
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "error: invalid version '$1' (expected X.Y.Z or X.Y.Z-prerelease)" >&2
+  exit 1
+fi
+
+if [[ ! "$sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "error: invalid sha256 '$sha256' (expected 64 lowercase hex chars)" >&2
+  exit 1
+fi
+
+formula=$(cat <<EOF
+# Formula template for a personal tap (e.g. github.com/wcgomes/homebrew-tap).
+# After each release: set version, url (if needed), and sha256 of the arm64 tarball.
+# See packaging/homebrew/README.md.
+
+class Adevcontainer < Formula
+  desc "Native Swift CLI for devcontainer.json on Apple container"
+  homepage "https://github.com/wcgomes/apple-dev-containers"
+  version "${version}"
+  url "https://github.com/wcgomes/apple-dev-containers/releases/download/v#{version}/adevcontainer-macos-arm64.tar.gz"
+  sha256 "${sha256}"
+  license "MIT"
+
+  depends_on macos: :tahoe # macOS 26+
+  depends_on arch: :arm64
+
+  def install
+    bin.install "adevcontainer"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/adevcontainer --version")
+  end
+
+  def caveats
+    <<~EOS
+      adevcontainer requires the Apple container CLI on the host (not installed by this formula):
+        https://github.com/apple/container
+
+      After install, run:
+        adevcontainer doctor
+    EOS
+  end
+end
+EOF
+)
+
+if [[ -z "$out" || "$out" == "-" ]]; then
+  printf '%s\n' "$formula"
+else
+  mkdir -p "$(dirname "$out")"
+  printf '%s\n' "$formula" >"$out"
+fi


### PR DESCRIPTION
## Summary
Automate Homebrew formula updates when a non-prerelease GitHub Release is published.

- **`scripts/render-homebrew-formula.sh`** — deterministic formula render with version + sha256 validation (64 lowercase hex)
- **`release.yml`** after Create GitHub Release:
  - Export tarball SHA256 from the package step
  - **Skip** Homebrew steps when version contains `-` (prerelease)
  - **Tap bump**: clone `wcgomes/homebrew-tap` with `HOMEBREW_TAP_TOKEN`, render `Formula/adevcontainer.rb`, commit `adevcontainer X.Y.Z`, push `main` (fails clearly if secret missing)
  - **Packaging mirror PR**: branch `brew-bump-vX.Y.Z` from `main`, update `packaging/homebrew/adevcontainer.rb`, open PR (`contents` + `pull-requests` write)
- **`packaging/homebrew/README.md`** — documents auto-update flow and required secret

## Maintainer action required
Add repo secret **`HOMEBREW_TAP_TOKEN`**: fine-grained PAT with Contents R/W on `wcgomes/homebrew-tap` only (or classic `repo` scope).

## Test plan
- [x] Local: script exact-match against current formula; rejects bad version/sha; accepts prerelease version format
- [x] YAML parses
- [x] CI green on this PR
- [x] After merge + secret set: cut a non-prerelease tag and confirm tap push + packaging PR
- [x] Prerelease tag (`vX.Y.Z-rc.1`) skips brew steps