### PR TITLE
fix: thread host localEnv through volume-mode rebuild

### DIFF
--- a/Sources/ADevContainerLib/Commands/ConfigReader.swift
+++ b/Sources/ADevContainerLib/Commands/ConfigReader.swift
@@ -142,6 +142,7 @@ public enum ConfigReader {
         labels: [String: String],
         containerId: String,
         runtime: AppleContainerRuntime,
+        localEnv: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) throws -> ResolvedVolumeConfigRead {
         do {
@@ -154,6 +155,7 @@ public enum ConfigReader {
             let config = try resolveRawVolume(
                 raw: raw,
                 labels: labels,
+                localEnv: localEnv,
                 fileManager: fileManager
             )
             return ResolvedVolumeConfigRead(config: config, raw: raw)
@@ -168,7 +170,7 @@ public enum ConfigReader {
     public static func resolveVolumeFile(
         at configPath: String,
         labels: [String: String],
-        localEnv: [String: String] = [:],
+        localEnv: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) throws -> ResolvedWorkspace {
         guard labels[ContainerIdentity.labelWorkspaceMode] == ContainerIdentity.workspaceModeVolume else {
@@ -249,6 +251,7 @@ public enum ConfigReader {
                 labels: labels,
                 containerId: containerId,
                 runtime: runtime,
+                localEnv: localEnv,
                 fileManager: fileManager
             )
         }
@@ -298,6 +301,7 @@ public enum ConfigReader {
         labels: [String: String],
         containerId: String,
         runtime: AppleContainerRuntime,
+        localEnv: [String: String],
         fileManager: FileManager
     ) throws -> ResolvedDevContainerConfig? {
         let raw = try readVolumeRawOnce(
@@ -307,12 +311,18 @@ public enum ConfigReader {
             fileManager: fileManager
         )
 
-        return try resolveRawVolume(raw: raw, labels: labels, fileManager: fileManager)
+        return try resolveRawVolume(
+            raw: raw,
+            labels: labels,
+            localEnv: localEnv,
+            fileManager: fileManager
+        )
     }
 
     private static func resolveRawVolume(
         raw: RawVolumeConfig,
         labels: [String: String],
+        localEnv: [String: String],
         fileManager: FileManager
     ) throws -> ResolvedDevContainerConfig {
 
@@ -349,7 +359,7 @@ public enum ConfigReader {
         let resolved = try resolveVolumeFile(
             at: tempConfig.path,
             labels: labels,
-            localEnv: [:],
+            localEnv: localEnv,
             fileManager: fileManager
         )
         return resolved.config

--- a/Sources/ADevContainerLib/Commands/RebuildCommand.swift
+++ b/Sources/ADevContainerLib/Commands/RebuildCommand.swift
@@ -148,6 +148,7 @@ public enum RebuildCommand {
                 labels: labels,
                 containerId: selected.id,
                 runtime: runtime,
+                localEnv: localEnv,
                 fileManager: fileManager
             )
             resolvedConfig = volumeRead!.config

--- a/Sources/ADevContainerLib/Commands/RecoveryConfigSession.swift
+++ b/Sources/ADevContainerLib/Commands/RecoveryConfigSession.swift
@@ -342,7 +342,7 @@ public final class RecoveryConfigSession: @unchecked Sendable {
     /// `ConfigReader.read`; the private temp directory's basename is never used.
     @discardableResult
     public func validateEditedConfig(
-        localEnv: [String: String] = [:]
+        localEnv: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> ResolvedWorkspace {
         try validateSecureState()
         _ = try readTempBytes()

--- a/Tests/adevcontainerTests/AllUnitTests.swift
+++ b/Tests/adevcontainerTests/AllUnitTests.swift
@@ -2309,11 +2309,13 @@ nonisolated(unsafe) let phase4UnitTests: [(String, () throws -> Void)] = [
         try MiniTest.expectEqual(String(data: buffer, encoding: .utf8) ?? "", "")
     }),
     ("lifecycleObjectMapRunsInParallel", {
-        let secondStarted = DispatchSemaphore(value: 0)
+        let rendezvous = DispatchGroup()
+        rendezvous.enter()
+        rendezvous.enter()
         let lock = NSLock()
-        var firstSawSecond = false
         var inFlight = 0
         var maxInFlight = 0
+        var rendezvousOk = 0
 
         let mock = MockProcessRunner()
         mock.handlers = [
@@ -2328,13 +2330,13 @@ nonisolated(unsafe) let phase4UnitTests: [(String, () throws -> Void)] = [
                     inFlight -= 1
                     lock.unlock()
                 }
-                if args.contains("first-cmd") {
-                    let wait = secondStarted.wait(timeout: .now() + 2)
-                    firstSawSecond = (wait == .success)
-                    return ProcessResult(exitCode: 0, stdout: Data(), stderr: Data())
-                }
-                if args.contains("second-cmd") {
-                    secondStarted.signal()
+                if args.contains("first-cmd") || args.contains("second-cmd") {
+                    rendezvous.leave()
+                    if rendezvous.wait(timeout: .now() + 2) == .success {
+                        lock.lock()
+                        rendezvousOk += 1
+                        lock.unlock()
+                    }
                     return ProcessResult(exitCode: 0, stdout: Data(), stderr: Data())
                 }
                 return ProcessResult(exitCode: 0, stdout: Data(), stderr: Data())
@@ -2357,7 +2359,7 @@ nonisolated(unsafe) let phase4UnitTests: [(String, () throws -> Void)] = [
             runtime: runtime,
             failurePolicy: .deleteContainerThenFail
         )
-        try MiniTest.expect(firstSawSecond, "first exec must still be in flight when second starts")
+        try MiniTest.expect(rendezvousOk == 2, "first exec must still be in flight when second starts")
         try MiniTest.expect(maxInFlight >= 2, "object-map entries must overlap")
         let execs = mock.calls.filter { $0.arguments.first == "exec" }
         try MiniTest.expectEqual(execs.count, 2)

--- a/Tests/adevcontainerTests/ConfigReaderTests.swift
+++ b/Tests/adevcontainerTests/ConfigReaderTests.swift
@@ -305,6 +305,152 @@ nonisolated(unsafe) let configReaderTests: [(String, () throws -> Void)] = [
         })
     }),
 
+    ("strictVolumeReadSubstitutesHostLocalEnvInMountSource", {
+        let configText = """
+        {
+          "image": "alpine:3.20",
+          "mounts": [
+            "source=${localEnv:HOME}${localEnv:USERPROFILE}/.kube/config,target=/home/vscode/.kube/config,type=bind,readonly"
+          ]
+        }
+        """
+        let mock = MockProcessRunner()
+        mock.handlers.append { args in
+            if args.first == "exec", args.dropFirst(2).first == "cat" {
+                return ProcessResult(exitCode: 0, stdout: Data(configText.utf8), stderr: Data())
+            }
+            return nil
+        }
+        let config = try ConfigReader.read(
+            labels: volumeLabels(configFile: ".devcontainer/devcontainer.json", workspaceFolder: "/workspaces/plantsuite"),
+            containerId: "c1",
+            runtime: mockRuntime(mock),
+            localEnv: ["HOME": "/Users/you"],
+            mode: .strict
+        )
+        try MiniTest.expectEqual(config?.mounts.count, 1)
+        try MiniTest.expectEqual(config?.mounts.first?.source, "/Users/you/.kube/config")
+        try MiniTest.expectEqual(config?.mounts.first?.target, "/home/vscode/.kube/config")
+        try MiniTest.expectEqual(config?.workspaceFolder, "/workspaces/plantsuite")
+    }),
+
+    ("strictVolumeReadEmptyLocalEnvCollapsesKubeConfigToRoot", {
+        let configText = """
+        {
+          "image": "alpine:3.20",
+          "mounts": [
+            "source=${localEnv:HOME}${localEnv:USERPROFILE}/.kube/config,target=/home/vscode/.kube/config,type=bind,readonly"
+          ]
+        }
+        """
+        let mock = MockProcessRunner()
+        mock.handlers.append { args in
+            if args.first == "exec", args.dropFirst(2).first == "cat" {
+                return ProcessResult(exitCode: 0, stdout: Data(configText.utf8), stderr: Data())
+            }
+            return nil
+        }
+        let config = try ConfigReader.read(
+            labels: volumeLabels(configFile: ".devcontainer/devcontainer.json", workspaceFolder: "/workspaces/plantsuite"),
+            containerId: "c1",
+            runtime: mockRuntime(mock),
+            localEnv: [:],
+            mode: .strict
+        )
+        try MiniTest.expectEqual(config?.mounts.first?.source, "/.kube/config")
+    }),
+
+    ("readVolumeWithRawSubstitutesHostLocalEnvInMountSource", {
+        let configText = """
+        {
+          "image": "alpine:3.20",
+          "mounts": [
+            "source=${localEnv:HOME}${localEnv:USERPROFILE}/.kube/config,target=/home/vscode/.kube/config,type=bind,readonly"
+          ]
+        }
+        """
+        let mock = MockProcessRunner()
+        mock.handlers.append { args in
+            if args.first == "exec", args.dropFirst(2).first == "cat" {
+                return ProcessResult(exitCode: 0, stdout: Data(configText.utf8), stderr: Data())
+            }
+            return nil
+        }
+        let resolved = try ConfigReader.readVolumeWithRaw(
+            labels: volumeLabels(configFile: ".devcontainer/devcontainer.json", workspaceFolder: "/workspaces/plantsuite"),
+            containerId: "c1",
+            runtime: mockRuntime(mock),
+            localEnv: ["HOME": "/Users/you"]
+        )
+        try MiniTest.expectEqual(resolved.config.mounts.first?.source, "/Users/you/.kube/config")
+        try MiniTest.expectEqual(resolved.config.workspaceFolder, "/workspaces/plantsuite")
+    }),
+
+    ("resolveVolumeFileHostLocalEnvExpandsKubeConfigIdiom", {
+        let json = """
+        {
+          "image": "alpine:3.20",
+          "mounts": [
+            "source=${localEnv:HOME}${localEnv:USERPROFILE}/.kube/config,target=/home/vscode/.kube/config,type=bind,readonly"
+          ]
+        }
+        """
+        let ws = try TestRepo.makeTempWorkspace(configJSON: json)
+        let configFile = ws.appendingPathComponent(".devcontainer/devcontainer.json").path
+        let resolved = try ConfigReader.resolveVolumeFile(
+            at: configFile,
+            labels: volumeLabels(configFile: ".devcontainer/devcontainer.json", workspaceFolder: "/workspaces/plantsuite"),
+            localEnv: ["HOME": "/Users/you"]
+        )
+        try MiniTest.expectEqual(resolved.config.mounts.first?.source, "/Users/you/.kube/config")
+        try MiniTest.expectEqual(resolved.config.workspaceFolder, "/workspaces/plantsuite")
+        try MiniTest.expect(
+            (resolved.workspacePath as NSString).lastPathComponent != "plantsuite",
+            "temp guest-config root must not become workspace identity"
+        )
+    }),
+
+    ("resolveVolumeFileEmptyLocalEnvCollapsesKubeConfigToRoot", {
+        let json = """
+        {
+          "image": "alpine:3.20",
+          "mounts": [
+            "source=${localEnv:HOME}${localEnv:USERPROFILE}/.kube/config,target=/home/vscode/.kube/config,type=bind,readonly"
+          ]
+        }
+        """
+        let ws = try TestRepo.makeTempWorkspace(configJSON: json)
+        let configFile = ws.appendingPathComponent(".devcontainer/devcontainer.json").path
+        let resolved = try ConfigReader.resolveVolumeFile(
+            at: configFile,
+            labels: volumeLabels(configFile: ".devcontainer/devcontainer.json", workspaceFolder: "/workspaces/plantsuite"),
+            localEnv: [:]
+        )
+        try MiniTest.expectEqual(resolved.config.mounts.first?.source, "/.kube/config")
+    }),
+
+    ("strictBindReadSubstitutesLocalEnvInMountSource", {
+        let json = """
+        {
+          "image": "alpine:3.20",
+          "mounts": [
+            "source=${localEnv:HOME}${localEnv:USERPROFILE}/.kube/config,target=/home/vscode/.kube/config,type=bind,readonly"
+          ]
+        }
+        """
+        let ws = try TestRepo.makeTempWorkspace(configJSON: json)
+        let configFile = ws.appendingPathComponent(".devcontainer/devcontainer.json").path
+        let config = try ConfigReader.read(
+            labels: bindLabels(localFolder: ws.path, configFile: configFile),
+            containerId: "c1",
+            runtime: mockRuntime(MockProcessRunner()),
+            localEnv: ["HOME": "/Users/you"],
+            mode: .strict
+        )
+        try MiniTest.expectEqual(config?.mounts.first?.source, "/Users/you/.kube/config")
+        try MiniTest.expectEqual(config?.workspaceFolder, "/workspaces/\(ws.lastPathComponent)")
+    }),
+
     ("strictVolumeMissingConfigFileLabelIsConfigNotFound", {
         let mock = MockProcessRunner()
         try MiniTest.expectThrows({

--- a/Tests/adevcontainerTests/RecoveryConfigSessionTests.swift
+++ b/Tests/adevcontainerTests/RecoveryConfigSessionTests.swift
@@ -140,6 +140,22 @@ nonisolated(unsafe) let recoveryConfigSessionTests: [(String, () throws -> Void)
         try MiniTest.expect(!resolved.workspacePath.hasSuffix("repository"), "private temp basename is not used")
     }),
 
+    ("recoveryValidationSubstitutesHostLocalEnvInMountSource", {
+        let raw = Data("""
+        {
+          "image": "alpine:3.20",
+          "mounts": [
+            "source=${localEnv:HOME}${localEnv:USERPROFILE}/.kube/config,target=/home/vscode/.kube/config,type=bind,readonly"
+          ]
+        }
+        """.utf8)
+        let session = try makeRecoverySession(raw: raw)
+        defer { try? session.cleanup() }
+        let resolved = try session.validateEditedConfig(localEnv: ["HOME": "/Users/you"])
+        try MiniTest.expectEqual(resolved.config.mounts.first?.source, "/Users/you/.kube/config")
+        try MiniTest.expectEqual(resolved.config.workspaceFolder, "/workspaces/repository")
+    }),
+
     ("recoverySessionRejectsConfigPathOutsideWorkspace", {
         for path in ["../../etc/passwd", "/etc/passwd"] {
             try MiniTest.expectThrows({


### PR DESCRIPTION
## Summary

Volume-mode `rebuild` failed after a successful `clone` when `devcontainer.json` used the host kubeconfig idiom `${localEnv:HOME}${localEnv:USERPROFILE}/.kube/config`.

- ConfigReader volume resolve passed an empty `localEnv`, so both substitutions collapsed and the bind source became `/.kube/config`.
- Bind-mode `up` already threaded the host environment and expanded correctly.
- Thread host `localEnv` through volume-mode `read` / `readVolumeWithRaw` / `resolveVolumeFile`, `RebuildCommand`, and recovery validation.
- Default empty maps now fall back to `ProcessInfo.processInfo.environment`.
- Tests cover host expansion, the empty-`localEnv` collapse to `/.kube/config`, bind-mode parity, and recovery validation.

## Commits

- `a87162f` fix: thread host localEnv through volume-mode rebuild
