### PR TITLE
feat: print feature names on lifecycle hook phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apple Dev Container CLI (adevcontainer)
 
 [![CI](https://github.com/wcgomes/apple-devcontainers/actions/workflows/ci.yml/badge.svg)](https://github.com/wcgomes/apple-devcontainers/actions/workflows/ci.yml)
-[![tests](https://img.shields.io/badge/tests-842%2B-brightgreen)](https://github.com/wcgomes/apple-devcontainers)
+[![tests](https://img.shields.io/badge/tests-843%2B-brightgreen)](https://github.com/wcgomes/apple-devcontainers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Native Swift CLI that reads `devcontainer.json` and runs development environments on Apple [`container`](https://github.com/apple/container).

--- a/Sources/ADevContainerLib/Commands/LifecycleRunner.swift
+++ b/Sources/ADevContainerLib/Commands/LifecycleRunner.swift
@@ -166,7 +166,7 @@ public enum LifecycleRunner {
         runtime: AppleContainerRuntime,
         failurePolicy: FailurePolicy
     ) throws {
-        StatusPrinter.status("Running", item: property)
+        emitRunningStatus(property)
         // Stream hook logs live (teed to host stderr) so long postCreate/etc scripts do not
         // look stuck. Capture is retained for failure diagnostics; QUIET only silences status.
         let execResult = try runtime.exec(
@@ -302,7 +302,7 @@ public enum LifecycleRunner {
 
     private static func createPathStages(
         config: ResolvedDevContainerConfig
-    ) -> [(String, LifecycleCommand?, [LifecycleCommand])] {
+    ) -> [(String, LifecycleCommand?, [NamedLifecycleCommand])] {
         [
             ("onCreateCommand", config.onCreateCommand, config.featureOnCreateCommands),
             ("updateContentCommand", config.updateContentCommand, config.featureUpdateContentCommands),
@@ -338,12 +338,14 @@ public enum LifecycleRunner {
                 failurePolicy: .deleteContainerThenFail
             )
             for (extraIndex, extra) in extras.enumerated() {
-                let label = extras.count == 1
-                    ? "\(property) (feature)"
-                    : "\(property) (feature \(extraIndex + 1))"
                 try runIfPresent(
-                    property: label,
-                    command: extra,
+                    property: featureHookProperty(
+                        property,
+                        name: extra.name,
+                        index: extraIndex,
+                        count: extras.count
+                    ),
+                    command: extra.command,
                     containerId: containerId,
                     config: config,
                     runtime: runtime,
@@ -372,12 +374,14 @@ public enum LifecycleRunner {
             failurePolicy: .failKeepContainer
         )
         for (index, extra) in config.featurePostStartCommands.enumerated() {
-            let label = config.featurePostStartCommands.count == 1
-                ? "postStartCommand (feature)"
-                : "postStartCommand (feature \(index + 1))"
             try runIfPresent(
-                property: label,
-                command: extra,
+                property: featureHookProperty(
+                    "postStartCommand",
+                    name: extra.name,
+                    index: index,
+                    count: config.featurePostStartCommands.count
+                ),
+                command: extra.command,
                 containerId: containerId,
                 config: config,
                 runtime: runtime,
@@ -424,12 +428,14 @@ public enum LifecycleRunner {
             failurePolicy: .failKeepContainer
         )
         for (index, extra) in config.featurePostAttachCommands.enumerated() {
-            let label = config.featurePostAttachCommands.count == 1
-                ? "postAttachCommand (feature)"
-                : "postAttachCommand (feature \(index + 1))"
             try runIfPresent(
-                property: label,
-                command: extra,
+                property: featureHookProperty(
+                    "postAttachCommand",
+                    name: extra.name,
+                    index: index,
+                    count: config.featurePostAttachCommands.count
+                ),
+                command: extra.command,
                 containerId: containerId,
                 config: config,
                 runtime: runtime,
@@ -561,7 +567,7 @@ public enum LifecycleRunner {
         command: LifecycleCommand,
         currentDirectory: String
     ) throws {
-        StatusPrinter.status("Running", item: property)
+        emitRunningStatus(property)
         let invocation = hostInvocation(command)
         let runner = hostProcessRunner()
         let result: ProcessResult
@@ -599,6 +605,38 @@ public enum LifecycleRunner {
             return (first, Array(argv.dropFirst()))
         }
         return ("/usr/bin/env", argv)
+    }
+
+    /// Phase target is the feature id when known; fall back to "feature" / "feature N".
+    static func featureHookProperty(
+        _ property: String,
+        name: String,
+        index: Int,
+        count: Int
+    ) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return "\(property) (\(trimmed))"
+        }
+        if count == 1 {
+            return "\(property) (feature)"
+        }
+        return "\(property) (feature \(index + 1))"
+    }
+
+    /// Prefer `item:` for the parenthetical target (feature name / object-map entry).
+    static func emitRunningStatus(_ property: String) {
+        if property.hasSuffix(")"),
+           let range = property.range(of: " (", options: .backwards)
+        {
+            let base = String(property[..<range.lowerBound])
+            let item = String(property[range.upperBound..<property.index(before: property.endIndex)])
+            if !base.isEmpty && !item.isEmpty {
+                StatusPrinter.status("Running \(base)", item: "(\(item))")
+                return
+            }
+        }
+        StatusPrinter.status("Running", item: property)
     }
 
     private static func lifecycleError(

--- a/Sources/ADevContainerLib/Commands/PostAttachConfigLoader.swift
+++ b/Sources/ADevContainerLib/Commands/PostAttachConfigLoader.swift
@@ -136,7 +136,12 @@ public enum PostAttachConfigLoader {
         cacheRoot: String = FeatureCache.defaultRoot(),
         fileManager: FileManager = .default
     ) {
-        if !config.featurePostStartCommands.isEmpty && !config.featurePostAttachCommands.isEmpty {
+        let needsNames = config.featurePostStartCommands.contains { $0.name.isEmpty }
+            || config.featurePostAttachCommands.contains { $0.name.isEmpty }
+        if !config.featurePostStartCommands.isEmpty
+            && !config.featurePostAttachCommands.isEmpty
+            && !needsNames
+        {
             return
         }
         guard !config.features.isEmpty else { return }
@@ -160,18 +165,47 @@ public enum PostAttachConfigLoader {
         guard let contrib = try? FeatureContributionMerge.collect(from: ordered) else { return }
         if config.featurePostStartCommands.isEmpty && !contrib.postStartCommands.isEmpty {
             config.featurePostStartCommands = contrib.postStartCommands
+        } else {
+            config.featurePostStartCommands = overlayNames(
+                config.featurePostStartCommands,
+                contrib.postStartCommands
+            )
         }
         if config.featurePostAttachCommands.isEmpty && !contrib.postAttachCommands.isEmpty {
             config.featurePostAttachCommands = contrib.postAttachCommands
+        } else {
+            config.featurePostAttachCommands = overlayNames(
+                config.featurePostAttachCommands,
+                contrib.postAttachCommands
+            )
+        }
+    }
+
+    private static func overlayNames(
+        _ existing: [NamedLifecycleCommand],
+        _ named: [NamedLifecycleCommand]
+    ) -> [NamedLifecycleCommand] {
+        existing.map { entry in
+            if !entry.name.isEmpty { return entry }
+            guard let match = named.first(where: { $0.command == entry.command && !$0.name.isEmpty }) else {
+                return entry
+            }
+            return NamedLifecycleCommand(name: match.name, command: entry.command)
         }
     }
 
     private static func uniqueAppend(
-        _ first: [LifecycleCommand],
-        _ second: [LifecycleCommand]
-    ) -> [LifecycleCommand] {
+        _ first: [NamedLifecycleCommand],
+        _ second: [NamedLifecycleCommand]
+    ) -> [NamedLifecycleCommand] {
         var out = first
-        for cmd in second where !out.contains(cmd) {
+        for cmd in second {
+            if let idx = out.firstIndex(where: { $0.command == cmd.command }) {
+                if out[idx].name.isEmpty && !cmd.name.isEmpty {
+                    out[idx] = cmd
+                }
+                continue
+            }
             out.append(cmd)
         }
         return out

--- a/Sources/ADevContainerLib/Commands/RecoveryOrchestrator.swift
+++ b/Sources/ADevContainerLib/Commands/RecoveryOrchestrator.swift
@@ -912,7 +912,7 @@ public enum RecoveryOrchestrator {
     private static func isPostAttachFailure(_ error: Error) -> Bool {
         guard let property = (error as? CLIError)?.property else { return false }
         return property == "postAttachCommand"
-            || property.hasPrefix("postAttachCommand (feature")
+            || property.hasPrefix("postAttachCommand (")
     }
 
     private static func sanitizedHelperID(_ helperID: String) -> String {

--- a/Sources/ADevContainerLib/Config/DevContainerConfig.swift
+++ b/Sources/ADevContainerLib/Config/DevContainerConfig.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-/// One entry in a lifecycle object-map (name → leaf command).
+/// One entry in a lifecycle object-map (name → leaf command), or a
+/// feature-contributed hook labeled with the feature id.
 public struct NamedLifecycleCommand: Equatable, Sendable {
     public var name: String
     public var command: LifecycleCommand
@@ -8,6 +9,13 @@ public struct NamedLifecycleCommand: Equatable, Sendable {
     public init(name: String, command: LifecycleCommand) {
         self.name = name
         self.command = command
+    }
+
+    public var execArguments: [String] { command.execArguments }
+
+    /// Unnamed leaf — used when remelted metadata has no feature `id`.
+    public static func shell(_ value: String) -> NamedLifecycleCommand {
+        NamedLifecycleCommand(name: "", command: .shell(value))
     }
 }
 
@@ -267,11 +275,12 @@ public struct ResolvedDevContainerConfig: Equatable {
     /// Admitted OCI features (empty = no Features runner work).
     public var features: [AdmittedFeature]
     /// Extra lifecycle hooks contributed by features (run after config hooks per stage).
-    public var featureOnCreateCommands: [LifecycleCommand]
-    public var featureUpdateContentCommands: [LifecycleCommand]
-    public var featurePostCreateCommands: [LifecycleCommand]
-    public var featurePostStartCommands: [LifecycleCommand]
-    public var featurePostAttachCommands: [LifecycleCommand]
+    /// `name` is the feature id when known (phase item); empty when remelted metadata has none.
+    public var featureOnCreateCommands: [NamedLifecycleCommand]
+    public var featureUpdateContentCommands: [NamedLifecycleCommand]
+    public var featurePostCreateCommands: [NamedLifecycleCommand]
+    public var featurePostStartCommands: [NamedLifecycleCommand]
+    public var featurePostAttachCommands: [NamedLifecycleCommand]
 
     public init(
         name: String? = nil,
@@ -298,11 +307,11 @@ public struct ResolvedDevContainerConfig: Equatable {
         vscodeExtensions: [String] = [],
         vscodeSettingsJSON: Data = Data("{}".utf8),
         features: [AdmittedFeature] = [],
-        featureOnCreateCommands: [LifecycleCommand] = [],
-        featureUpdateContentCommands: [LifecycleCommand] = [],
-        featurePostCreateCommands: [LifecycleCommand] = [],
-        featurePostStartCommands: [LifecycleCommand] = [],
-        featurePostAttachCommands: [LifecycleCommand] = []
+        featureOnCreateCommands: [NamedLifecycleCommand] = [],
+        featureUpdateContentCommands: [NamedLifecycleCommand] = [],
+        featurePostCreateCommands: [NamedLifecycleCommand] = [],
+        featurePostStartCommands: [NamedLifecycleCommand] = [],
+        featurePostAttachCommands: [NamedLifecycleCommand] = []
     ) {
         self.name = name
         self.image = image

--- a/Sources/ADevContainerLib/Features/DevContainerMetadataLabel.swift
+++ b/Sources/ADevContainerLib/Features/DevContainerMetadataLabel.swift
@@ -34,9 +34,13 @@ public enum DevContainerMetadataLabel {
     /// Used to bake `devcontainer.metadata` onto a derived image so resume can remelt.
     public static func encodeFragments(_ contributions: FeatureContributions) -> String? {
         var fragments: [[String: Any]] = []
-        func append(_ key: String, _ commands: [LifecycleCommand]) {
-            for cmd in commands {
-                fragments.append([key: cmd.hashEncoding])
+        func append(_ key: String, _ commands: [NamedLifecycleCommand]) {
+            for entry in commands {
+                var fragment: [String: Any] = [key: entry.command.hashEncoding]
+                if !entry.name.isEmpty {
+                    fragment["id"] = entry.name
+                }
+                fragments.append(fragment)
             }
         }
         append("onCreateCommand", contributions.onCreateCommands)
@@ -159,23 +163,35 @@ public enum DevContainerMetadataLabel {
         if let rawMounts = dict["mounts"], let mounts = try? MountParser.parse(rawMounts) {
             c.mounts = mounts
         }
-        if let cmd = try? LifecycleCommand.parse(dict["onCreateCommand"], property: "onCreateCommand") {
-            c.onCreateCommands = [cmd]
+        if let hook = namedHook(dict["onCreateCommand"], property: "onCreateCommand", fragment: dict) {
+            c.onCreateCommands = [hook]
         }
-        if let cmd = try? LifecycleCommand.parse(dict["updateContentCommand"], property: "updateContentCommand") {
-            c.updateContentCommands = [cmd]
+        if let hook = namedHook(dict["updateContentCommand"], property: "updateContentCommand", fragment: dict) {
+            c.updateContentCommands = [hook]
         }
-        if let cmd = try? LifecycleCommand.parse(dict["postCreateCommand"], property: "postCreateCommand") {
-            c.postCreateCommands = [cmd]
+        if let hook = namedHook(dict["postCreateCommand"], property: "postCreateCommand", fragment: dict) {
+            c.postCreateCommands = [hook]
         }
-        if let cmd = try? LifecycleCommand.parse(dict["postStartCommand"], property: "postStartCommand") {
-            c.postStartCommands = [cmd]
+        if let hook = namedHook(dict["postStartCommand"], property: "postStartCommand", fragment: dict) {
+            c.postStartCommands = [hook]
         }
-        if let cmd = try? LifecycleCommand.parse(dict["postAttachCommand"], property: "postAttachCommand") {
-            c.postAttachCommands = [cmd]
+        if let hook = namedHook(dict["postAttachCommand"], property: "postAttachCommand", fragment: dict) {
+            c.postAttachCommands = [hook]
         }
         // privileged / securityOpt are not merged; caller warns via warnStripUnsafe.
         return c
+    }
+
+    private static func namedHook(
+        _ value: Any?,
+        property: String,
+        fragment: [String: Any]
+    ) -> NamedLifecycleCommand? {
+        guard let command = try? LifecycleCommand.parse(value, property: property) else {
+            return nil
+        }
+        let name = FeatureRef.hookDisplayName(metadataId: fragment["id"] as? String)
+        return NamedLifecycleCommand(name: name, command: command)
     }
 
     private static func union(_ a: FeatureContributions, _ b: FeatureContributions) -> FeatureContributions {

--- a/Sources/ADevContainerLib/Features/FeatureContributionMerge.swift
+++ b/Sources/ADevContainerLib/Features/FeatureContributionMerge.swift
@@ -6,22 +6,22 @@ public struct FeatureContributions: Equatable, Sendable {
     public var capAdd: [String]
     public var containerEnv: [String: String]
     public var mounts: [MountSpec]
-    public var onCreateCommands: [LifecycleCommand]
-    public var updateContentCommands: [LifecycleCommand]
-    public var postCreateCommands: [LifecycleCommand]
-    public var postStartCommands: [LifecycleCommand]
-    public var postAttachCommands: [LifecycleCommand]
+    public var onCreateCommands: [NamedLifecycleCommand]
+    public var updateContentCommands: [NamedLifecycleCommand]
+    public var postCreateCommands: [NamedLifecycleCommand]
+    public var postStartCommands: [NamedLifecycleCommand]
+    public var postAttachCommands: [NamedLifecycleCommand]
 
     public init(
         initProcess: Bool = false,
         capAdd: [String] = [],
         containerEnv: [String: String] = [:],
         mounts: [MountSpec] = [],
-        onCreateCommands: [LifecycleCommand] = [],
-        updateContentCommands: [LifecycleCommand] = [],
-        postCreateCommands: [LifecycleCommand] = [],
-        postStartCommands: [LifecycleCommand] = [],
-        postAttachCommands: [LifecycleCommand] = []
+        onCreateCommands: [NamedLifecycleCommand] = [],
+        updateContentCommands: [NamedLifecycleCommand] = [],
+        postCreateCommands: [NamedLifecycleCommand] = [],
+        postStartCommands: [NamedLifecycleCommand] = [],
+        postAttachCommands: [NamedLifecycleCommand] = []
     ) {
         self.initProcess = initProcess
         self.capAdd = capAdd
@@ -56,11 +56,22 @@ public enum FeatureContributionMerge {
                 }
             }
             result.mounts.append(contentsOf: meta.mounts)
-            if let c = meta.onCreateCommand { result.onCreateCommands.append(c) }
-            if let c = meta.updateContentCommand { result.updateContentCommands.append(c) }
-            if let c = meta.postCreateCommand { result.postCreateCommands.append(c) }
-            if let c = meta.postStartCommand { result.postStartCommands.append(c) }
-            if let c = meta.postAttachCommand { result.postAttachCommands.append(c) }
+            let name = FeatureRef.hookDisplayName(metadataId: meta.id, reference: f.admitted.reference)
+            if let c = meta.onCreateCommand {
+                result.onCreateCommands.append(NamedLifecycleCommand(name: name, command: c))
+            }
+            if let c = meta.updateContentCommand {
+                result.updateContentCommands.append(NamedLifecycleCommand(name: name, command: c))
+            }
+            if let c = meta.postCreateCommand {
+                result.postCreateCommands.append(NamedLifecycleCommand(name: name, command: c))
+            }
+            if let c = meta.postStartCommand {
+                result.postStartCommands.append(NamedLifecycleCommand(name: name, command: c))
+            }
+            if let c = meta.postAttachCommand {
+                result.postAttachCommands.append(NamedLifecycleCommand(name: name, command: c))
+            }
         }
         return result
     }

--- a/Sources/ADevContainerLib/Features/FeatureRef.swift
+++ b/Sources/ADevContainerLib/Features/FeatureRef.swift
@@ -115,6 +115,23 @@ public enum FeatureRef {
         return (withoutTag as NSString).lastPathComponent
     }
 
+    /// Phase-item name for a feature hook: metadata `id` when present, else last-segment ref.
+    public static func hookDisplayName(metadataId: String?, reference: String? = nil) -> String {
+        if let metadataId {
+            let trimmed = metadataId.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return featureId(from: trimmed)
+            }
+        }
+        if let reference {
+            let trimmed = reference.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return featureId(from: trimmed)
+            }
+        }
+        return ""
+    }
+
     /// Match dependsOn / installsAfter keys against selected refs (id, full ref, or prefix).
     public static func matchesDependencyKey(_ key: String, selectedRef: String) -> Bool {
         if key == selectedRef { return true }

--- a/Sources/ADevContainerLib/Support/TerminalStyle.swift
+++ b/Sources/ADevContainerLib/Support/TerminalStyle.swift
@@ -108,7 +108,7 @@ public enum TerminalStyle {
     /// Phase line: bold blue. Trailing "item" (parenthetical or resource token) is bold white.
     ///
     /// Examples (color on):
-    /// - `==> Running postStartCommand (feature 1)` → blue head + white `(feature 1)`
+    /// - `==> Running postStartCommand (agents-workspace)` → blue head + white `(agents-workspace)`
     /// - `==> Pulling image alpine:3.20` → blue head + white `alpine:3.20`
     /// - `==> Ready` → all blue
     public static func stylePhase(_ text: String, color: Bool? = nil) -> String {
@@ -138,7 +138,7 @@ public enum TerminalStyle {
         }
         guard !body.isEmpty else { return nil }
 
-        // 1) Trailing parenthetical: "Running postStartCommand (feature 1)"
+        // 1) Trailing parenthetical: "Running postStartCommand (agents-workspace)"
         if body.hasSuffix(")"), let open = body.lastIndex(of: "("), open > body.startIndex {
             let before = body.index(before: open)
             if body[before] == " " {
@@ -268,6 +268,26 @@ public enum TerminalStyle {
         return ansiDim + text + ansiReset
     }
 
+    /// Official-style `[<id>-<hook>]` prefix (e.g. `[agents-workspace-poststart]`).
+    /// Display-only: capture buffers stay raw.
+    public static func stripLifecycleHookLogPrefix(_ line: String) -> String {
+        guard line.first == "[", let close = line.firstIndex(of: "]") else {
+            return line
+        }
+        let tag = String(line[line.index(after: line.startIndex)..<close])
+        guard let dash = tag.lastIndex(of: "-") else { return line }
+        let hook = String(tag[tag.index(after: dash)...]).lowercased()
+        let known: Set<String> = [
+            "initialize", "oncreate", "updatecontent", "postcreate", "poststart", "postattach"
+        ]
+        guard known.contains(hook) else { return line }
+        var rest = String(line[line.index(after: close)...])
+        if rest.hasPrefix(" ") {
+            rest.removeFirst()
+        }
+        return rest
+    }
+
     /// Frame one display line of internal tool output: indent + `| ` + content.
     public static func frameToolLine(_ line: String, color: Bool? = nil) -> String {
         // Normalize CR leftovers from CRLF without double-prefixing.
@@ -275,6 +295,7 @@ public enum TerminalStyle {
         if content.hasSuffix("\r") {
             content = String(content.dropLast())
         }
+        content = stripLifecycleHookLogPrefix(content)
         let framed = nestIndent + toolPipePrefix + content
         return styleToolLine(framed, color: color)
     }

--- a/Tests/adevcontainerTests/AllUnitTests.swift
+++ b/Tests/adevcontainerTests/AllUnitTests.swift
@@ -2471,6 +2471,7 @@ nonisolated(unsafe) let phase4UnitTests: [(String, () throws -> Void)] = [
             "postAttachCommand",
             "postCreateCommand (feature)",
             "postStartCommand (setup)",
+            "postStartCommand (agents-workspace)",
             "postCreateCommand (feature 2)",
         ]
         for property in cases {
@@ -2502,6 +2503,57 @@ nonisolated(unsafe) let phase4UnitTests: [(String, () throws -> Void)] = [
             failurePolicy: .failKeepContainer
         )
         try MiniTest.expectEqual(String(data: buffer, encoding: .utf8) ?? "", "")
+    }),
+    ("lifecycleRunnerFeatureHookPhaseUsesFeatureName", {
+        let previousEnabled = StatusPrinter.enabled
+        let previousWrite = StatusPrinter.writeStderr
+        let previousPhase = StatusPrinter.hasEmittedPhase
+        let previousColor = TerminalStyle.colorOverride
+        defer {
+            StatusPrinter.enabled = previousEnabled
+            StatusPrinter.writeStderr = previousWrite
+            StatusPrinter.hasEmittedPhase = previousPhase
+            TerminalStyle.colorOverride = previousColor
+        }
+        TerminalStyle.colorOverride = false
+        StatusPrinter.enabled = true
+        var buffer = Data()
+        StatusPrinter.writeStderr = { buffer.append($0) }
+
+        let mock = MockProcessRunner()
+        mock.handlers = [
+            { args in
+                if args.first == "exec" {
+                    return ProcessResult(exitCode: 0, stdout: Data(), stderr: Data())
+                }
+                return nil
+            }
+        ]
+        let runtime = AppleContainerRuntime(executablePath: "/usr/local/bin/container", runner: mock)
+        let config = ResolvedDevContainerConfig(
+            image: "alpine:3.20",
+            workspaceFolder: "/workspaces/app",
+            userEnvProbe: .none,
+            featurePostStartCommands: [
+                NamedLifecycleCommand(
+                    name: "agents-workspace",
+                    command: .shell("echo hi")
+                )
+            ]
+        )
+        StatusPrinter.resetSectionState()
+        try LifecycleRunner.runRestartPostStart(
+            containerId: "ctr-named-feature",
+            config: config,
+            runtime: runtime
+        )
+        let out = String(data: buffer, encoding: .utf8) ?? ""
+        try MiniTest.expect(
+            out.contains("==> Running postStartCommand (agents-workspace)\n"),
+            "feature hook phase item is the feature name"
+        )
+        try MiniTest.expect(!out.contains("(feature 1)"), "must not use feature-N labels when the name is known")
+        try MiniTest.expect(!out.contains("[agents-workspace-poststart]"), "must not prefix hook bodies with [slug-hook]")
     }),
     ("lifecycleObjectMapRunsInParallel", {
         let rendezvous = DispatchGroup()
@@ -3643,8 +3695,14 @@ nonisolated(unsafe) let featuresUnitTests: [(String, () throws -> Void)] = [
         let parsed = DevContainerMetadataLabel.parseContributions(from: [
             DevContainerMetadataLabel.labelKey: encoded!
         ])
-        try MiniTest.expectEqual(parsed.postStartCommands, [.shell("echo baked-postStart")])
-        try MiniTest.expectEqual(parsed.postAttachCommands, [.shell("echo baked-postAttach")])
+        try MiniTest.expectEqual(
+            parsed.postStartCommands,
+            [NamedLifecycleCommand(name: "hook-feature", command: .shell("echo baked-postStart"))]
+        )
+        try MiniTest.expectEqual(
+            parsed.postAttachCommands,
+            [NamedLifecycleCommand(name: "hook-feature", command: .shell("echo baked-postAttach"))]
+        )
     }),
     ("featureDockerfileGeneratorBakesUnionedBaseAndFeatureMetadata", {
         // Derived LABEL must persist base-image hooks, not overwrite with features-only.
@@ -3714,13 +3772,15 @@ nonisolated(unsafe) let featuresUnitTests: [(String, () throws -> Void)] = [
             DevContainerMetadataLabel.labelKey: encoded!
         ])
         try MiniTest.expectEqual(
-            parsed.postStartCommands,
+            parsed.postStartCommands.map(\.command),
             [.shell("echo base-postStart"), .shell("echo feature-postStart")]
         )
+        try MiniTest.expectEqual(parsed.postStartCommands.map(\.name), ["", "hook-feature"])
         try MiniTest.expectEqual(
-            parsed.postAttachCommands,
+            parsed.postAttachCommands.map(\.command),
             [.shell("echo base-postAttach"), .shell("echo feature-postAttach")]
         )
+        try MiniTest.expectEqual(parsed.postAttachCommands.map(\.name), ["", "hook-feature"])
     }),
     ("featureDockerfileGeneratorInstallSeesContainerEnv", {
         // Feature metadata containerEnv (e.g. DOTNET_ROOT) must reach install.sh.

--- a/Tests/adevcontainerTests/Support/TerminalStyleTests.swift
+++ b/Tests/adevcontainerTests/Support/TerminalStyleTests.swift
@@ -124,6 +124,21 @@ nonisolated(unsafe) let terminalStyleTests: [(String, () throws -> Void)] = [
         try MiniTest.expectEqual(framed, "    | npm install")
         let mono = TerminalStyle.frameToolLine("line\r", color: false)
         try MiniTest.expectEqual(mono, "    | line")
+        try MiniTest.expectEqual(
+            TerminalStyle.frameToolLine(
+                "[agents-workspace-poststart] Marker found, checking for updates...",
+                color: false
+            ),
+            "    | Marker found, checking for updates..."
+        )
+        try MiniTest.expectEqual(
+            TerminalStyle.stripLifecycleHookLogPrefix("[agents-workspace-poststart] agents-workspace update available (092b07a)"),
+            "agents-workspace update available (092b07a)"
+        )
+        try MiniTest.expectEqual(
+            TerminalStyle.stripLifecycleHookLogPrefix("[INFO] keep this"),
+            "[INFO] keep this"
+        )
     }),
     ("terminalStyleMonochromeWhenColorFalse", {
         let phase = TerminalStyle.stylePhase("==> Ready", color: false)
@@ -161,17 +176,17 @@ nonisolated(unsafe) let terminalStyleTests: [(String, () throws -> Void)] = [
     }),
     ("terminalStylePhaseItemParentheticalWhite", {
         let line = TerminalStyle.stylePhase(
-            "==> Running postStartCommand (feature 1)",
+            "==> Running postStartCommand (agents-workspace)",
             color: true
         )
         try MiniTest.expectEqual(
             TerminalStyle.stripANSI(line),
-            "==> Running postStartCommand (feature 1)"
+            "==> Running postStartCommand (agents-workspace)"
         )
         try MiniTest.expect(line.contains(TerminalStyle.ansiPhaseCyan))
         try MiniTest.expect(line.contains(TerminalStyle.ansiBold))
         // Item is white (bold default), not blue-wrapped alone as full line.
-        let item = TerminalStyle.styleCommand("(feature 1)", color: true)
+        let item = TerminalStyle.styleCommand("(agents-workspace)", color: true)
         try MiniTest.expect(line.contains(item))
         let head = TerminalStyle.stylePhaseHead("==> Running postStartCommand ", color: true)
         try MiniTest.expect(line.hasPrefix(head) || line.contains(head))
@@ -205,10 +220,10 @@ nonisolated(unsafe) let terminalStyleTests: [(String, () throws -> Void)] = [
     }),
     ("terminalStylePhaseItemMonochromeUnchanged", {
         let line = TerminalStyle.stylePhase(
-            "==> Running postStartCommand (feature 1)",
+            "==> Running postStartCommand (agents-workspace)",
             color: false
         )
-        try MiniTest.expectEqual(line, "==> Running postStartCommand (feature 1)")
+        try MiniTest.expectEqual(line, "==> Running postStartCommand (agents-workspace)")
         try MiniTest.expect(!line.contains("\u{001B}"))
     }),
 ]

--- a/Tests/adevcontainerTests/VSCodeOpenTests.swift
+++ b/Tests/adevcontainerTests/VSCodeOpenTests.swift
@@ -1066,7 +1066,7 @@ nonisolated(unsafe) let vscodeOpenCommandTests: [(String, () throws -> Void)] = 
             ContainerIdentity.labelLocalFolder: ws.path,
             ContainerIdentity.labelConfigFile: ws.appendingPathComponent(".devcontainer/devcontainer.json").path,
             ContainerIdentity.labelWorkspaceFolder: "/workspaces/app",
-            DevContainerMetadataLabel.labelKey: #"{"postStartCommand":"echo feature-postStart"}"#
+            DevContainerMetadataLabel.labelKey: #"{"id":"agents-workspace","postStartCommand":"echo feature-postStart"}"#
         ]
         let entry = MockProcessRunner.containerListJSON(
             id: "adev-app-aaaabbbbcccc",
@@ -1123,8 +1123,8 @@ nonisolated(unsafe) let vscodeOpenCommandTests: [(String, () throws -> Void)] = 
             "real start must print postStart status when that hook is present"
         )
         try MiniTest.expect(
-            mono.contains("==> Running postStartCommand (feature)"),
-            "real start must print feature-labeled postStart status"
+            mono.contains("==> Running postStartCommand (agents-workspace)"),
+            "real start must print feature-named postStart status"
         )
         try MiniTest.expect(
             mono.contains("==> Running postAttachCommand"),
@@ -1152,7 +1152,7 @@ nonisolated(unsafe) let vscodeOpenCommandTests: [(String, () throws -> Void)] = 
             labels: labels,
             image: "alpine:3.20"
         )
-        let metaJSON = #"{"postStartCommand":"echo feature-only-postStart"}"#
+        let metaJSON = #"{"id":"agents-workspace","postStartCommand":"echo feature-only-postStart"}"#
         var execBodies: [String] = []
         let mock = MockProcessRunner()
         mock.handlers = [
@@ -1195,8 +1195,8 @@ nonisolated(unsafe) let vscodeOpenCommandTests: [(String, () throws -> Void)] = 
         try MiniTest.expect(mock.calls.contains { $0.arguments.first == "start" })
         try MiniTest.expect(execBodies.contains("echo feature-only-postStart"), "feature postStart from image metadata must remelt")
         try MiniTest.expect(
-            mono.contains("==> Running postStartCommand (feature)"),
-            "real start must print feature-labeled postStart when that is the only hook"
+            mono.contains("==> Running postStartCommand (agents-workspace)"),
+            "real start must print feature-named postStart when that is the only hook"
         )
         try MiniTest.expect(mono.contains("==> Ready"))
     }),
@@ -1220,7 +1220,7 @@ nonisolated(unsafe) let vscodeOpenCommandTests: [(String, () throws -> Void)] = 
             labels: labels,
             image: "alpine:3.20"
         )
-        let metaJSON = #"{"postStartCommand":"echo meta-only-postStart","postAttachCommand":"echo meta-only-postAttach"}"#
+        let metaJSON = #"{"id":"agents-workspace","postStartCommand":"echo meta-only-postStart","postAttachCommand":"echo meta-only-postAttach"}"#
         var execBodies: [String] = []
         let mock = MockProcessRunner()
         mock.handlers = [
@@ -1277,8 +1277,8 @@ nonisolated(unsafe) let vscodeOpenCommandTests: [(String, () throws -> Void)] = 
         try MiniTest.expect(!execBodies.contains("echo postCreate"))
         try MiniTest.expect(!mock.calls.contains { $0.arguments.first == "delete" })
         try MiniTest.expect(
-            mono.contains("==> Running postStartCommand (feature)"),
-            "feature-only postStart must print feature-labeled status"
+            mono.contains("==> Running postStartCommand (agents-workspace)"),
+            "feature-only postStart must print feature-named status"
         )
         try MiniTest.expect(mono.contains("==> Ready"))
     }),
@@ -1364,8 +1364,8 @@ nonisolated(unsafe) let vscodeOpenCommandTests: [(String, () throws -> Void)] = 
         let mono = TerminalStyle.stripANSI(stderr)
         try MiniTest.expect(execBodies.contains("echo feature-local-postStart"), "local feature postStart must remelt when metadata is absent")
         try MiniTest.expect(
-            mono.contains("==> Running postStartCommand (feature)"),
-            "real start must print feature-labeled postStart from equivalent remelt source"
+            mono.contains("==> Running postStartCommand (hook-feature)"),
+            "real start must print feature-named postStart from equivalent remelt source"
         )
     }),
     ("alreadyRunningStartEmitsAlreadyRunningAndReady", {


### PR DESCRIPTION
Feature lifecycle hooks print the feature name instead of `feature N`.

- Phase lines are `==> Running postStartCommand (agents-workspace)`, not `(feature 1)`.
- Hook log bodies no longer get `[slug-hook]` prefixes such as `[agents-workspace-poststart]`.
- Same StatusPrinter `item:` pattern for all lifecycle Commands.
- README tests badge 842+ → 843+.
