### PR TITLE
patch: rename list column to SOURCE with bind path display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apple Dev Container CLI (adevcontainer)
 
 [![CI](https://github.com/wcgomes/apple-devcontainers/actions/workflows/ci.yml/badge.svg)](https://github.com/wcgomes/apple-devcontainers/actions/workflows/ci.yml)
-[![tests](https://img.shields.io/badge/tests-843%2B-brightgreen)](https://github.com/wcgomes/apple-devcontainers)
+[![tests](https://img.shields.io/badge/tests-845%2B-brightgreen)](https://github.com/wcgomes/apple-devcontainers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Native Swift CLI that reads `devcontainer.json` and runs development environments on Apple [`container`](https://github.com/apple/container).

--- a/Sources/ADevContainerLib/Support/ManagedContainerTable.swift
+++ b/Sources/ADevContainerLib/Support/ManagedContainerTable.swift
@@ -17,6 +17,25 @@ public enum ManagedContainerTable {
         return s + String(repeating: " ", count: width - s.count)
     }
 
+    /// Display-only abbreviation of a path under the user's home directory:
+    /// equal to home (trailing `/` included) → `~`, under home → `~/…`, otherwise unchanged.
+    /// Operates on the standardized path as-is: no normalization of `..` / duplicate slashes
+    /// (labels are standardized at stamp time).
+    /// Explicit home-prefix logic (not `NSString.abbreviatingWithTildeInPath`; Linux-portable).
+    public static func abbreviatePath(
+        _ path: String,
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path
+    ) -> String {
+        if path == homeDirectory || path == homeDirectory + "/" {
+            return "~"
+        }
+        let prefix = homeDirectory + "/"
+        if path.hasPrefix(prefix) {
+            return "~" + path.dropFirst(homeDirectory.count)
+        }
+        return path
+    }
+
     /// Column widths for a container set. `lead` is the picker prefix column (0 for `list`).
     public struct Widths: Sendable {
         public let lead: Int
@@ -40,7 +59,7 @@ public enum ManagedContainerTable {
         4 + String(max(count, 1)).count
     }
 
-    /// Dim header: optional blank lead, then NAME STATE MODE GIT_URL.
+    /// Dim header: optional blank lead, then NAME STATE MODE SOURCE.
     public static func header(widths: Widths) -> String {
         TerminalStyle.styleInfo(plainHeader(widths: widths))
     }
@@ -53,7 +72,7 @@ public enum ManagedContainerTable {
         s += pad("NAME", widths.name)
             + gap + pad("STATE", widths.state)
             + gap + pad("MODE", modeWidth)
-            + gap + "GIT_URL"
+            + gap + "SOURCE"
         return s
     }
 
@@ -65,7 +84,14 @@ public enum ManagedContainerTable {
     ) -> String {
         let name = displayName(for: info)
         let mode = info.labels[ContainerIdentity.labelWorkspaceMode] ?? "-"
-        let git = info.labels[ContainerIdentity.labelGitURL] ?? ""
+        let path: String
+        if info.labels[ContainerIdentity.labelWorkspaceMode] == ContainerIdentity.workspaceModeBind {
+            path = abbreviatePath(info.labels[ContainerIdentity.labelLocalFolder] ?? "")
+        } else if info.labels[ContainerIdentity.labelWorkspaceMode] == ContainerIdentity.workspaceModeVolume {
+            path = info.labels[ContainerIdentity.labelGitURL] ?? ""
+        } else {
+            path = ""
+        }
 
         var out = ""
         if widths.lead > 0 {
@@ -80,7 +106,7 @@ public enum ManagedContainerTable {
         out += TerminalStyle.styleCommand(pad(mode, modeWidth))
         out += gap
         // Default foreground, normal weight (not dim, not bold).
-        out += git
+        out += path
         return out
     }
 

--- a/Tests/adevcontainerTests/ListCommandTests.swift
+++ b/Tests/adevcontainerTests/ListCommandTests.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Human `list` table color / monochrome / JSON contracts (InteractivePicker-aligned cells).
 nonisolated(unsafe) let listCommandTests: [(String, () throws -> Void)] = [
-    ("listHumanTableColorsNameStateModeGit", {
+    ("listHumanTableColorsNameStateModeSource", {
         let previousColor = TerminalStyle.colorOverride
         defer { TerminalStyle.colorOverride = previousColor }
         TerminalStyle.colorOverride = true
@@ -20,7 +20,8 @@ nonisolated(unsafe) let listCommandTests: [(String, () throws -> Void)] = [
                     id: "adev-stop-ddddeeeeffff",
                     state: "stopped",
                     mode: "bind",
-                    git: ""
+                    git: "",
+                    localFolder: "/host/workspace/app"
                 ),
             ]
         )
@@ -37,10 +38,12 @@ nonisolated(unsafe) let listCommandTests: [(String, () throws -> Void)] = [
         try MiniTest.expect(table.contains(TerminalStyle.styleMuted("stopped", color: true)))
         try MiniTest.expect(table.contains(TerminalStyle.styleCommand("volume", color: true)))
         try MiniTest.expect(table.contains(TerminalStyle.styleCommand("bind  ", color: true)))
-        // GIT_URL: default fg, normal weight (unstyled when color on).
+        // SOURCE: default fg, normal weight (unstyled when color on).
         try MiniTest.expect(table.contains("https://github.com/org/app"))
         try MiniTest.expect(!table.contains(TerminalStyle.styleInfo("https://github.com/org/app", color: true)))
         try MiniTest.expect(!table.contains(TerminalStyle.styleCommand("https://github.com/org/app", color: true)))
+        // SOURCE cell is mode-dependent: bind row shows local_folder path.
+        try MiniTest.expect(table.contains("/host/workspace/app"))
         // Header is dim chrome; stopped STATE uses muted gray (not the same SGR as dim).
         let headerLine = plain.split(separator: "\n", omittingEmptySubsequences: false).first.map(String.init) ?? ""
         try MiniTest.expect(headerLine.contains("NAME") && headerLine.contains("STATE") && headerLine.contains("MODE"))
@@ -51,6 +54,78 @@ nonisolated(unsafe) let listCommandTests: [(String, () throws -> Void)] = [
         )
         try MiniTest.expect(plain.contains("adev-run-aaaabbbbcccc"))
         try MiniTest.expect(plain.contains("adev-stop-ddddeeeeffff"))
+    }),
+    ("managedContainerTableAbbreviatePathRules", {
+        let home = "/home/dev"
+        // Equal to home → "~".
+        try MiniTest.expectEqual(
+            ManagedContainerTable.abbreviatePath(home, homeDirectory: home),
+            "~"
+        )
+        // Home with a trailing slash → "~" (collapse, not "~/").
+        try MiniTest.expectEqual(
+            ManagedContainerTable.abbreviatePath(home + "/", homeDirectory: home),
+            "~"
+        )
+        // Under home → "~/…", remainder preserved (including deeper nesting).
+        try MiniTest.expectEqual(
+            ManagedContainerTable.abbreviatePath(home + "/workspace/app", homeDirectory: home),
+            "~/workspace/app"
+        )
+        try MiniTest.expectEqual(
+            ManagedContainerTable.abbreviatePath(home + "/a/b/c", homeDirectory: home),
+            "~/a/b/c"
+        )
+        // Outside home → unchanged.
+        try MiniTest.expectEqual(
+            ManagedContainerTable.abbreviatePath("/host/workspace/app", homeDirectory: home),
+            "/host/workspace/app"
+        )
+        // Home-prefix sibling ("/home/dev2") is not under home.
+        try MiniTest.expectEqual(
+            ManagedContainerTable.abbreviatePath("/home/dev2/app", homeDirectory: home),
+            "/home/dev2/app"
+        )
+        // Empty path → unchanged.
+        try MiniTest.expectEqual(
+            ManagedContainerTable.abbreviatePath("", homeDirectory: home),
+            ""
+        )
+    }),
+    ("listHumanTableAbbreviatesHomeUnderBindPath", {
+        let previousColor = TerminalStyle.colorOverride
+        defer { TerminalStyle.colorOverride = previousColor }
+        TerminalStyle.colorOverride = false
+
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let bindPath = home + "/workspace/app"
+        let runtime = try listTestRuntime(
+            entries: [
+                listManagedEntry(
+                    id: "adev-bind-hhhhhhhh",
+                    state: "running",
+                    mode: "bind",
+                    git: "",
+                    localFolder: bindPath
+                ),
+                listManagedEntry(
+                    id: "adev-vol-gggggggg",
+                    state: "running",
+                    mode: "volume",
+                    git: "https://github.com/org/app"
+                ),
+            ]
+        )
+        let table = try ListCommand.run(options: ListOptions(jsonOutput: false), runtime: runtime)
+        // Bind-mode SOURCE under the real home renders ~/… (display-only).
+        try MiniTest.expect(table.contains("~/workspace/app"))
+        try MiniTest.expect(!table.contains(bindPath))
+        // Volume-mode SOURCE (git URL) is never abbreviated.
+        try MiniTest.expect(table.contains("https://github.com/org/app"))
+        // Label stays unchanged: list JSON still carries the full local_folder path
+        // (JSONSerialization pretty-printed output escapes "/" as "\/").
+        let json = try ListCommand.run(options: ListOptions(jsonOutput: true), runtime: runtime)
+        try MiniTest.expect(json.contains(bindPath.replacingOccurrences(of: "/", with: "\\/")))
     }),
     ("listHumanTableMonochromeWhenColorDisabled", {
         let previousColor = TerminalStyle.colorOverride
@@ -81,7 +156,7 @@ nonisolated(unsafe) let listCommandTests: [(String, () throws -> Void)] = [
         try MiniTest.expect(table.contains("NAME"))
         try MiniTest.expect(table.contains("STATE"))
         try MiniTest.expect(table.contains("MODE"))
-        try MiniTest.expect(table.contains("GIT_URL"))
+        try MiniTest.expect(table.contains("SOURCE"))
     }),
     ("listJSONUnchangedMonochromeEvenWhenColorEnabled", {
         let previousColor = TerminalStyle.colorOverride
@@ -151,7 +226,8 @@ nonisolated(unsafe) let listCommandTests: [(String, () throws -> Void)] = [
                     id: "short",
                     state: "running",
                     mode: "bind",
-                    git: "https://example.com/a.git"
+                    git: "",
+                    localFolder: "/host/workspace/app"
                 ),
                 listManagedEntry(
                     id: "longer-name-here",
@@ -192,7 +268,8 @@ private func listManagedEntry(
     id: String,
     state: String,
     mode: String,
-    git: String
+    git: String,
+    localFolder: String = ""
 ) -> [String: Any] {
     var labels: [String: String] = [
         ContainerIdentity.labelManaged: ContainerIdentity.managedValue,
@@ -200,6 +277,9 @@ private func listManagedEntry(
     ]
     if !git.isEmpty {
         labels[ContainerIdentity.labelGitURL] = git
+    }
+    if !localFolder.isEmpty {
+        labels[ContainerIdentity.labelLocalFolder] = localFolder
     }
     return MockProcessRunner.containerListJSON(id: id, state: state, labels: labels)
 }

--- a/Tests/adevcontainerTests/Support/InteractivePickerTests.swift
+++ b/Tests/adevcontainerTests/Support/InteractivePickerTests.swift
@@ -5,11 +5,12 @@ private func pickerContainers() -> [ContainerInfo] {
     [
         ContainerInfo(id: "adev-a-111", name: "adev-a-111", state: "running", labels: [
             ContainerIdentity.labelManaged: ContainerIdentity.managedValue,
-            ContainerIdentity.labelGitURL: "https://example.com/a.git",
+            ContainerIdentity.labelLocalFolder: "/host/workspace/a",
             ContainerIdentity.labelWorkspaceMode: ContainerIdentity.workspaceModeBind,
         ], image: "alpine"),
         ContainerInfo(id: "adev-b-222", name: "adev-b-222", state: "stopped", labels: [
             ContainerIdentity.labelManaged: ContainerIdentity.managedValue,
+            ContainerIdentity.labelGitURL: "https://example.com/b.git",
             ContainerIdentity.labelWorkspaceMode: ContainerIdentity.workspaceModeVolume,
         ], image: "alpine"),
         ContainerInfo(id: "adev-c-333", name: "adev-c-333", state: "running", labels: [
@@ -163,7 +164,7 @@ nonisolated(unsafe) let interactivePickerTests: [(String, () throws -> Void)] = 
         let plain = TerminalStyle.stripANSI(box.text)
         try MiniTest.expect(plain.contains("Select a container:"))
         try MiniTest.expect(plain.contains("NAME") && plain.contains("STATE") && plain.contains("MODE"))
-        try MiniTest.expect(plain.contains("GIT_URL"))
+        try MiniTest.expect(plain.contains("SOURCE"))
         try MiniTest.expect(plain.contains("adev-a-111"))
         try MiniTest.expect(plain.contains("adev-b-222"))
         // Table state cells are plain text (no [brackets]), matching list.
@@ -201,10 +202,12 @@ nonisolated(unsafe) let interactivePickerTests: [(String, () throws -> Void)] = 
         try MiniTest.expect(box.text.contains(TerminalStyle.stylePhaseHead(aName, color: true)))
         try MiniTest.expect(box.text.contains(TerminalStyle.styleSuccess("running", color: true)))
         try MiniTest.expect(box.text.contains(TerminalStyle.styleMuted("stopped", color: true)))
-        // GIT_URL: default fg, normal weight (unstyled when color on).
-        try MiniTest.expect(box.text.contains("https://example.com/a.git"))
-        try MiniTest.expect(!box.text.contains(TerminalStyle.styleInfo("https://example.com/a.git", color: true)))
-        try MiniTest.expect(!box.text.contains(TerminalStyle.styleCommand("https://example.com/a.git", color: true)))
+        // SOURCE: default fg, normal weight (unstyled when color on).
+        // Bind row shows local_folder path; volume row shows git URL.
+        try MiniTest.expect(box.text.contains("/host/workspace/a"))
+        try MiniTest.expect(box.text.contains("https://example.com/b.git"))
+        try MiniTest.expect(!box.text.contains(TerminalStyle.styleInfo("/host/workspace/a", color: true)))
+        try MiniTest.expect(!box.text.contains(TerminalStyle.styleCommand("/host/workspace/a", color: true)))
         try MiniTest.expect(box.text.contains(TerminalStyle.styleCommand("bind  ", color: true)))
         try MiniTest.expect(box.text.contains(TerminalStyle.styleCommand("volume", color: true)))
         // Missing mode shows "-" like list.
@@ -245,10 +248,12 @@ nonisolated(unsafe) let interactivePickerTests: [(String, () throws -> Void)] = 
         try MiniTest.expect(box.text.contains(TerminalStyle.stylePhaseHead(bName, color: true)))
         try MiniTest.expect(box.text.contains(TerminalStyle.styleSuccess("running", color: true)))
         try MiniTest.expect(box.text.contains(TerminalStyle.styleMuted("stopped", color: true)))
-        // GIT_URL: default fg, normal weight (unstyled when color on).
-        try MiniTest.expect(box.text.contains("https://example.com/a.git"))
-        try MiniTest.expect(!box.text.contains(TerminalStyle.styleInfo("https://example.com/a.git", color: true)))
-        try MiniTest.expect(!box.text.contains(TerminalStyle.styleCommand("https://example.com/a.git", color: true)))
+        // SOURCE: default fg, normal weight (unstyled when color on).
+        // Bind row shows local_folder path; volume row shows git URL.
+        try MiniTest.expect(box.text.contains("/host/workspace/a"))
+        try MiniTest.expect(box.text.contains("https://example.com/b.git"))
+        try MiniTest.expect(!box.text.contains(TerminalStyle.styleInfo("/host/workspace/a", color: true)))
+        try MiniTest.expect(!box.text.contains(TerminalStyle.styleCommand("/host/workspace/a", color: true)))
         try MiniTest.expect(box.text.contains(TerminalStyle.styleCommand("bind  ", color: true)))
         try MiniTest.expect(box.text.contains(TerminalStyle.styleCommand("volume", color: true)))
         let plain = TerminalStyle.stripANSI(box.text)
@@ -260,7 +265,8 @@ nonisolated(unsafe) let interactivePickerTests: [(String, () throws -> Void)] = 
         try MiniTest.expect(plain.contains("running"))
         try MiniTest.expect(plain.contains("stopped"))
         try MiniTest.expect(!plain.contains("[running]"))
-        try MiniTest.expect(plain.contains("https://example.com/a.git"))
+        try MiniTest.expect(plain.contains("/host/workspace/a"))
+        try MiniTest.expect(plain.contains("https://example.com/b.git"))
         try MiniTest.expect(plain.contains("volume"))
     }),
     ("pickerListLineMonochromeWhenColorDisabled", {
@@ -289,11 +295,11 @@ nonisolated(unsafe) let interactivePickerTests: [(String, () throws -> Void)] = 
         try MiniTest.expect(box.text.contains("NAME"))
         try MiniTest.expect(box.text.contains("STATE"))
         try MiniTest.expect(box.text.contains("MODE"))
-        try MiniTest.expect(box.text.contains("GIT_URL"))
+        try MiniTest.expect(box.text.contains("SOURCE"))
         try MiniTest.expect(box.text.contains("  1) "))
         try MiniTest.expect(box.text.contains("adev-a-111"))
         try MiniTest.expect(box.text.contains("running"))
-        try MiniTest.expect(box.text.contains("https://example.com/a.git"))
+        try MiniTest.expect(box.text.contains("/host/workspace/a"))
         try MiniTest.expect(box.text.contains("bind"))
         try MiniTest.expect(box.text.contains("  2) "))
         try MiniTest.expect(box.text.contains("adev-b-222"))

--- a/wiki/conventions/cli-runtime-boundary.md
+++ b/wiki/conventions/cli-runtime-boundary.md
@@ -218,7 +218,7 @@ Apple named volumes mount **root:root** ([gaps](../domain/devcontainer-apple-gap
 
 ### InteractivePicker (multi-container)
 
-`ManagedContainers.resolveSelection` → **`InteractivePicker`** when `--name` omitted and more than one managed container. Code: `ManagedContainers.swift`, `TerminalRawInput.swift`. Rows/header via shared **`ManagedContainerTable`** (NAME STATE MODE GIT_URL; lead `>` / `N)` — [terminal-output](terminal-output.md#managed-container-table-list--interactivepicker)). Foreign create-name collision does not use this picker.
+`ManagedContainers.resolveSelection` → **`InteractivePicker`** when `--name` omitted and more than one managed container. Code: `ManagedContainers.swift`, `TerminalRawInput.swift`. Rows/header via shared **`ManagedContainerTable`** (NAME STATE MODE SOURCE; lead `>` / `N)` — [terminal-output](terminal-output.md#managed-container-table-list--interactivepicker)). Foreign create-name collision does not use this picker.
 
 | Mode | When | Behavior |
 |------|------|----------|

--- a/wiki/conventions/terminal-output.md
+++ b/wiki/conventions/terminal-output.md
@@ -68,7 +68,7 @@ Live-tee internal tools (hooks, Features build, clone populate `streamOutput: tr
 
 **`ManagedContainerTable`** shared human layout for `list` (stdout) and **InteractivePicker** (stderr). Code: `ManagedContainerTable.swift`.
 
-Columns (header dim `styleInfo`): **NAME STATE MODE GIT_URL**. Pad plain cells, then style (ANSI must not skew columns). Cell styles (color on): name `stylePhaseHead`; state `styleSuccess` when running else **`styleMuted`** (bold + 256 fg `245` — not weight-normal; distinct from header `styleInfo` dim); mode `styleCommand`; git plain default foreground (not dim, not bold). Recovery helpers append ` [RECOVERY]` on the name. Monochrome when color off; `list --json` monochrome.
+Columns (header dim `styleInfo`): **NAME STATE MODE SOURCE**. Pad plain cells, then style (ANSI must not skew columns). Cell styles (color on): name `stylePhaseHead`; state `styleSuccess` when running else **`styleMuted`** (bold + 256 fg `245` — not weight-normal; distinct from header `styleInfo` dim); mode `styleCommand`; SOURCE plain default foreground (not dim, not bold), showing `devcontainer.local_folder` for bind-mode containers and `devcontainer.git_url` for volume-mode containers (empty otherwise). Bind-mode paths under the user's home directory are displayed with `~` (`~/…`) — a display-only abbreviation; the `devcontainer.local_folder` label stays unchanged, and volume-mode git URLs are never abbreviated. Recovery helpers append ` [RECOVERY]` on the name. Monochrome when color off; `list --json` monochrome.
 
 | Surface | Stream | Lead column |
 |---------|--------|-------------|


### PR DESCRIPTION
Rename the shared `list`/picker table column `GIT_URL` → `SOURCE`.

- The `SOURCE` cell is now mode-dependent:
  - bind → `devcontainer.local_folder` host path, with display-only `~/...` home abbreviation
  - volume → `devcontainer.git_url`
- Labels, `--json` output, and identity are unchanged.
- README badge updated to 845 tests.